### PR TITLE
feat(blog): add English and Japanese versions of AI Actions post

### DIFF
--- a/content/en/blog/2026-04-06-ai-agent-github-actions-debug.md
+++ b/content/en/blog/2026-04-06-ai-agent-github-actions-debug.md
@@ -1,0 +1,143 @@
+---
+title: "I Asked an AI Agent to Fix GitHub Actions—and Stepped Into a Chain of Traps"
+date: 2026-04-06T21:35:00+09:00
+author: "Giko"
+image: "https://img.freepik.com/premium-vector/ai-coding-robot-assistant-programming-code-debugging-vector-illustration-concept_694862-52.jpg?w=1800"
+categories: ["Tech", "GitHub", "Workflow"]
+tags: ["GitHub Actions", "AI Agent", "CI/CD", "Debug"]
+draft: false
+---
+
+Over the past two days, I asked an AI agent to help me modify a GitHub Actions workflow. The goal sounded simple:
+
+- do not deploy during the PR stage
+- only run build and deploy after the PR is merged into `main`
+
+It sounded like a five-minute task. Instead, it turned into a neat collection of very typical mistakes. Which makes it a pretty good blog post.
+
+![Comic-style illustration of an AI agent debugging GitHub Actions](https://img.freepik.com/premium-vector/ai-coding-robot-assistant-programming-code-debugging-vector-illustration-concept_694862-52.jpg?w=1800)
+
+## The first misunderstanding: treating “merge into main” as a separate event
+
+The easiest mistake was to think of “PR merged into `main`” as a standalone GitHub Actions event parallel to `push`.
+
+But in GitHub’s actual event model:
+
+> **A PR merge into `main` is, in essence, a `push` to `main`.**
+
+So if your requirement is:
+
+- nothing should run on the PR
+- build and deploy should happen only after merge into `main`
+
+then the simplest and most stable workflow trigger is actually:
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+```
+
+That is not “going back to an old-school setup.” It is simply how GitHub models the event.
+
+## The second trap: trying to deploy GitHub Pages directly from a PR event
+
+The clearest error message I hit was this:
+
+> `refs/pull/47/merge is not allowed to deploy to github-pages due to environment protection rules`
+
+The core issue is:
+
+- the ref running in a PR is usually not `main`
+- it is something like `refs/pull/47/merge`
+- the `github-pages` deployment environment has protection rules against that ref
+
+In other words:
+
+**You can do build validation on a PR, but you should not run GitHub Pages deploy directly on a PR ref.**
+
+That is a platform rule, not something you can fully outsmart with two extra `if` lines in YAML.
+
+## The third trap: overcomplicating the trigger chain
+
+To get around the restriction, I tried a few “clever” patterns:
+
+- `pull_request` + `types: [closed]`
+- `workflow_run`
+- mixing PR validation and deploy branching logic in a single workflow
+
+These approaches are not always invalid, but they introduce a few problems:
+
+1. **they are harder to read**
+2. **they make it easier to misunderstand the real trigger path**
+3. **they make it easier for both the human and the AI to lose track of what is actually supposed to happen**
+
+This gets worse when an AI agent is making multiple iterative edits. You can easily end up in a state where each local fix seems reasonable, but the overall workflow becomes more and more confusing.
+
+## The stable solution
+
+In the end, the most reliable answer was also the plainest one:
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+```
+
+Then let the workflow do all of the following in one main-branch push:
+
+1. build
+2. upload artifact
+3. deploy pages
+
+If your repo governance requires every change to go through a PR merge before reaching `main`, then combine that with branch protection:
+
+- block direct pushes to `main`
+- require pull requests
+- require review / status checks
+
+With that setup, the semantics become:
+
+> **Build and deploy only when a PR is merged into main.**
+
+## One thing this made even clearer to me
+
+Using an AI agent to edit CI/CD config can absolutely speed things up.
+But it works best when the task is:
+
+- repetitive
+- narrow in scope
+- governed by clear rules
+
+Once the task involves:
+
+- platform event models
+- permission boundaries
+- changing requirements over multiple rounds
+- process constraints like “don’t open a new PR”, “rebase main first”, or “reuse the current branch”
+
+then it becomes very easy to fall into this pattern:
+
+> Every single AI step sounds reasonable, but the overall result drifts away from your real intent.
+
+That is not uniquely an AI problem. Humans do the same thing in complex workflows. The difference is just that AI can repeat the wrong move much faster.
+
+## My takeaway
+
+After all this, I’m keeping three rules in mind:
+
+1. **Understand the event model before editing the workflow.**
+2. **Do not deploy GitHub Pages from a PR ref.**
+3. **When using AI to modify process configuration, define the constraints clearly and sync the latest `main` before every round.**
+
+A lot of the time, the real time-saver is not “letting AI start immediately.”
+It is making the boundary and the goal explicit first.
+
+Otherwise the result looks like this:
+
+- lots of code changes
+- multiple PRs
+- many CI runs
+- but the original problem is still sitting there
+
+So this post is basically a field note from today’s mistakes.

--- a/content/ja/blog/2026-04-06-ai-agent-github-actions-debug.md
+++ b/content/ja/blog/2026-04-06-ai-agent-github-actions-debug.md
@@ -1,0 +1,150 @@
+---
+title: "AIエージェントにGitHub Actionsを直させたら、見事にハマった話"
+date: 2026-04-06T21:35:00+09:00
+author: "Giko"
+image: "https://img.freepik.com/premium-vector/ai-coding-robot-assistant-programming-code-debugging-vector-illustration-concept_694862-52.jpg?w=1800"
+categories: ["技術", "GitHub", "ワークフロー"]
+tags: ["GitHub Actions", "AI Agent", "CI/CD", "Debug"]
+draft: false
+---
+
+ここ数日、AIエージェントに GitHub Actions の修正を頼んでいました。目的はかなりシンプルです。
+
+- PR の段階では deploy しない
+- PR が `main` に merge されたあとだけ build と deploy を実行する
+
+数分で終わる小さな修正に見えたのですが、実際にはかなり典型的な落とし穴をいくつも踏みました。せっかくなので、ブログとして残しておきます。
+
+![GitHub Actions をデバッグしている AI エージェントの漫画風イラスト](https://img.freepik.com/premium-vector/ai-coding-robot-assistant-programming-code-debugging-vector-illustration-concept_694862-52.jpg?w=1800)
+
+## 最初の誤解：「main に merge される」は独立したイベントだと思っていた
+
+最初にやりがちな勘違いは、「PR が `main` に merge される」という出来事を、`push` とは別の独立した GitHub Actions イベントだと思ってしまうことです。
+
+でも GitHub の実際のイベントモデルでは、
+
+> **PR が `main` に merge されることは、本質的には `main` への `push` です。**
+
+なので、要件がこうであるなら：
+
+- PR 上では何も動かしたくない
+- `main` に merge されたあとだけ build + deploy したい
+
+一番素直で安定した書き方は、実はこれです。
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+```
+
+これは「古い書き方に戻った」のではなく、GitHub のイベントモデルにそのまま従っているだけです。
+
+## 2つ目の落とし穴：PR イベント上で GitHub Pages を直接 deploy しようとしたこと
+
+次にぶつかった、かなり分かりやすいエラーがこれでした。
+
+> `refs/pull/47/merge is not allowed to deploy to github-pages due to environment protection rules`
+
+ポイントはこうです。
+
+- PR 上で動く ref は通常 `main` ではない
+- `refs/pull/47/merge` のような ref になる
+- `github-pages` 環境には、その ref に対する保護ルールがある
+
+つまり、
+
+**PR 上で build の検証はできても、GitHub Pages の deploy を PR ref 上でそのまま実行するべきではない**
+
+ということです。
+
+これは YAML の `if` を少し足せば回避できる種類の話ではなく、プラットフォーム側の制約です。
+
+## 3つ目の落とし穴：制約を避けようとして、トリガーを複雑にしすぎたこと
+
+この制約を回避しようとして、途中でいくつか“賢そうな”書き方も試しました。
+
+- `pull_request` + `types: [closed]`
+- `workflow_run`
+- 1つの workflow の中で PR 検証と deploy 条件を分岐させる
+
+これらは完全に間違いというわけではありません。ただ、次のような問題を生みやすいです。
+
+1. **可読性が落ちる**
+2. **実際にどのイベントで何が動くのかを誤解しやすい**
+3. **人間も AI も、実際の実行経路を見失いやすい**
+
+特に AI エージェントに何度も連続で修正させる場合、局所的には正しそうな変更が積み重なって、全体としてはどんどん分かりにくくなる、という状態に入りやすいです。
+
+## 最終的に安定した解決策
+
+結局、最後に残ったのは一番素朴な形でした。
+
+```yaml
+on:
+  push:
+    branches: ["main"]
+```
+
+そして 1 回の `main` への push の中で、順番にこう処理します。
+
+1. build
+2. artifact の upload
+3. GitHub Pages への deploy
+
+もしリポジトリ運用として「`main` には必ず PR merge 経由でしか入れない」ようにしたいなら、さらに branch protection を組み合わせます。
+
+- `main` への直接 push を禁止する
+- PR を必須にする
+- review や status checks を必須にする
+
+これで意味としては、
+
+> **PR が main に merge されたときだけ build と deploy が走る**
+
+という状態になります。
+
+## 今回あらためてはっきりしたこと
+
+AI エージェントに CI/CD の設定変更を任せると、確かにスピードは上がります。
+でも本当に向いているのは、
+
+- 繰り返しが多い
+- 変更範囲が狭い
+- ルールが明確
+
+そういうタスクです。
+
+逆に、
+
+- プラットフォームのイベントモデル
+- 権限や保護ルール
+- 何度も変わる要件
+- 「新しい PR は作るな」「毎回 main を rebase しろ」「既存ブランチを使え」みたいな運用制約
+
+こういったものが絡んでくると、かなり簡単に次の状態になります。
+
+> AI の各ステップはそれぞれもっともらしいのに、最終結果は本来の意図からズレていく。
+
+これは AI 特有の問題ではなく、人間でも同じです。ただ AI は、間違った方向に進む速度も速いだけです。
+
+## 今回の結論
+
+今回の件で、自分の中では次の3つがかなりはっきりしました。
+
+1. **workflow を触る前に、イベントモデルを先に理解する**
+2. **GitHub Pages の deploy を PR ref 上でやらない**
+3. **AI に運用系の設定を直させるなら、制約を最初に明文化し、毎回最新の `main` を同期してから始める**
+
+多くの場合、本当に時間を節約するのは「AI にすぐ作業させること」ではなく、先に境界と目的をはっきりさせることです。
+
+そうしないと最後は、
+
+- 修正は何度も入った
+- PR もいくつもできた
+- CI も何度も回った
+- でも本当の問題はそのまま残っている
+
+ということになりがちです。
+
+というわけで、これは今日ハマったことの備忘録です。


### PR DESCRIPTION
为刚写的 GitHub Actions / AI 代理博文补充英文版和日文版，保持同一插图与核心内容一致。