### PR TITLE
[codex] Replace Disqus with Giscus comments

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -36,8 +36,23 @@ weight = 3
 [services.googleAnalytics]
 ID = 'G-1HTJ05548S' # see https://gohugo.io/templates/internal/#configure-google-analytics
 
-[services.disqus]
-shortname = 'themefisher-template' # we use disqus to show comments in blog posts . To install disqus please follow this tutorial https://portfolio.peter-baumgartner.net/2017/09/10/how-to-install-disqus-on-hugo/
+[params.comments]
+provider = "giscus"
+
+[params.comments.giscus]
+enable = true
+repo = "yougikou/yougikou.github.io"
+repo_id = "MDEwOlJlcG9zaXRvcnkyNDc5NjkxMTQ="
+category = "Announcements"
+category_id = "DIC_kwDODse1Ws4C-RZf"
+mapping = "pathname"
+strict = false
+reactions_enabled = true
+emit_metadata = false
+input_position = "bottom"
+theme = "preferred_color_scheme"
+lang = "zh-CN"
+loading = "lazy"
 
 ########################## Permalinks ############################
 [permalinks.page]

--- a/layouts/_partials/comments/giscus.html
+++ b/layouts/_partials/comments/giscus.html
@@ -1,0 +1,20 @@
+{{- $giscus := site.Params.comments.giscus -}}
+{{- if and $giscus.enable $giscus.repo $giscus.repo_id $giscus.category_id -}}
+  <div class="giscus"></div>
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="{{ $giscus.repo }}"
+    data-repo-id="{{ $giscus.repo_id }}"
+    {{ with $giscus.category }}data-category="{{ . }}"{{ end }}
+    data-category-id="{{ $giscus.category_id }}"
+    data-mapping="{{ $giscus.mapping | default `pathname` }}"
+    data-strict="{{ cond ($giscus.strict | default false) `1` `0` }}"
+    data-reactions-enabled="{{ cond ($giscus.reactions_enabled | default true) `1` `0` }}"
+    data-emit-metadata="{{ cond ($giscus.emit_metadata | default false) `1` `0` }}"
+    data-input-position="{{ $giscus.input_position | default `bottom` }}"
+    data-theme="{{ $giscus.theme | default `preferred_color_scheme` }}"
+    data-lang="{{ $giscus.lang | default site.Language.Lang }}"
+    data-loading="{{ $giscus.loading | default `lazy` }}"
+    crossorigin="anonymous"
+    async></script>
+{{- end -}}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,98 @@
+{{ define "main" }}
+  <section class="section pt-7">
+    <div class="container">
+      <div class="row justify-center">
+        <article class="lg:col-10">
+          {{ $image:= .Params.image }}
+          {{ if $image }}
+            <div class="mb-10">
+              {{ partial "image" (dict "Src" $image "Context" .Page "Alt" .Title "Class" "w-full rounded") }}
+            </div>
+          {{ end }}
+          <h1 class="h2 mb-4">
+            {{ .Title }}
+          </h1>
+          <ul class="mb-4">
+            <li class="mr-4 inline-block">
+              <a
+                href="{{ `authors/` | relLangURL }}{{ .Params.Author | urlize }}/">
+                <i class="fa-regular fa-circle-user mr-2"></i
+                >{{ .Params.author }}
+              </a>
+            </li>
+            {{ $categories:= .Params.categories }}
+            {{ if $categories }}
+              <li class="mr-4 inline-block">
+                <i class="fa-regular fa-folder mr-2"></i>
+                {{ range $i,$p:= $categories }}
+                  <a
+                    href="{{ `categories/` | relLangURL }}{{ . | urlize | lower }}/"
+                    class=""
+                    >{{ . | humanize }}{{ if ne $i (sub (len $categories) 1) }}
+                      {{ "," }}
+                    {{ end }}
+                  </a>
+                {{ end }}
+              </li>
+            {{ end }}
+            <li class="mr-4 inline-block">
+              <i class="fa-regular fa-clock mr-2"></i>
+              {{ time.Format ":date_long" .PublishDate }}
+            </li>
+          </ul>
+          <div class="content mb-10">
+            {{ partial "toc.html" (dict "Class" "blog" "Collapsed" false "TableOfContents" .TableOfContents ) }}
+            {{ .Content }}
+          </div>
+          <div class="row items-start justify-between">
+            {{ $tags:= .Params.tags }}
+            {{ if $tags }}
+              <div class="lg:col-6 mb-10 flex items-center lg:mb-0">
+                <h5 class="mr-3">{{ T "tags" | default "Tags" }} :</h5>
+                <ul>
+                  {{ range $i,$p:= $tags }}
+                    <li class="inline-block">
+                      <a
+                        class="bg-light hover:bg-primary dark:bg-darkmode-light dark:hover:bg-darkmode-primary dark:hover:text-text-dark m-1 block rounded px-3 py-1 hover:text-white"
+                        href="{{ `tags/` | relLangURL }}{{ . | urlize | lower }}/">
+                        {{ . | humanize }}
+                      </a>
+                    </li>
+                  {{ end }}
+                </ul>
+              </div>
+            {{ end }}
+            <div class="lg:col-6 flex items-center lg:justify-end">
+              <h5>{{ T "share" | default "Share" }} :</h5>
+              {{ partial "social-share" (dict "Context" . "Class" "share-icons" "Title" .Title "Whatsapp" false "Telegram" false "Linkedin" false "Pinterest" false "Tumblr" false "Vk" false "Reddit" false) }}
+            </div>
+          </div>
+          <!-- comments -->
+          {{ if eq site.Params.comments.provider "giscus" }}
+            <div class="mt-20">
+              {{ partial "comments/giscus.html" . }}
+            </div>
+          {{ end }}
+        </article>
+      </div>
+
+      <!-- Related posts -->
+      {{ $related := .Site.RegularPages.Related . | first 10 }}
+      {{ $related = $related | shuffle | first 3 }}
+      {{ with $related }}
+        <div class="section pb-0">
+          <h2 class="h3 mb-12">
+            {{ T "related_posts" | default "Related Posts" }}
+          </h2>
+          <div class="row">
+            {{ range . }}
+              <div class="lg:col-4 md:col-6 mb-14">
+                {{ partial "components/blog-card" . }}
+              </div>
+            {{ end }}
+          </div>
+        </div>
+      {{ end }}
+    </div>
+  </section>
+{{ end }}


### PR DESCRIPTION
## What changed

- Replaced the HugoPlate Disqus comment hook with a local article template override that renders a Giscus partial.
- Added Giscus configuration for `yougikou/yougikou.github.io` using the `Announcements` discussion category and `pathname` mapping.
- Removed the Disqus shortname configuration so the site no longer loads Disqus comments.

## Why

Disqus was the external ad-supported comment provider. Giscus keeps comments in GitHub Discussions, avoids ads, and fits the existing GitHub Pages/Hugo workflow.

## Validation

- Ran `/private/tmp/hugo --gc --minify --ignoreCache` with Hugo Extended 0.151.0.
- Confirmed generated article HTML contains `https://giscus.app/client.js` with the configured repo/category IDs.
- Confirmed generated article HTML no longer contains Disqus output.