### PR TITLE
[codex] Add AdSense display ad slots

### DIFF
--- a/DEVELOPER_DOCS.md
+++ b/DEVELOPER_DOCS.md
@@ -127,11 +127,19 @@ Notable sections:
 - Branding: `favicon`, `logo`, `logo_darkmode`, `logo_width`, `logo_height`, `logo_webp`.
 - Theme: `navbar_fixed`, `theme_switcher`, `theme_default` (light|dark|system).
 - Sections: `mainSections` (used for listing content like blog on various pages/widgets).
-- Tracking & Ads: `google_tag_manager`, `google_adsense`.
+- Tracking & Ads: `google_tag_manager`, `google_adsense`, `[adsense]`.
 - Inline script: `custom_script`.
 - Feature Tables: `[preloader]`, `[navigation_button]`, `[search]`, `[announcement]`, `[metadata]`, `[site_verification]`, `[cookies]`, `[mermaid]`, `[widgets]`, `[google_map]`, `[subscription]`.
 
 Enable/disable features with `enable = true|false` inside each table.
+
+AdSense revenue ads require all of these values in `config/_default/params.toml`:
+
+- `google_adsense`: Publisher ID from AdSense, for example `ca-pub-xxxxxxxxxxxxxxxx`.
+- `[adsense].article_bottom_slot`: Display ad unit slot shown after blog article content.
+- `[adsense].blog_list_slot`: Display ad unit slot shown inside the blog listing.
+
+The templates intentionally render nothing until both the publisher ID and a slot ID are configured.
 
 ### 3.3 Menus (`menus.en.toml`)
 

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -23,7 +23,7 @@ mainSections = ["blog"]
 contact_form_action = "https://airform.io/yougikou@gmail.com" # contact form works with [https://airform.io/] or [https://formspree.io]
 # google tag manager, see https://developers.google.com/tag-manager/
 google_tag_manager = "" # example: G-XXXXXXXXXX
-google_adsense = ""     # example: ca-pub-xxxxxxxxxxxxxxxx; required for AdSense revenue
+google_adsense = "ca-pub-7435544862471526" # required for AdSense revenue
 # custom script on header, example: custom_script= "<script>console.log(\"Hello World\")</script>"
 custom_script = ""
 # copyright

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -23,11 +23,17 @@ mainSections = ["blog"]
 contact_form_action = "https://airform.io/yougikou@gmail.com" # contact form works with [https://airform.io/] or [https://formspree.io]
 # google tag manager, see https://developers.google.com/tag-manager/
 google_tag_manager = "" # example: G-XXXXXXXXXX
-google_adsense = ""     # example: ca-pub-xxxxxxxxxxxxxxxx
+google_adsense = ""     # example: ca-pub-xxxxxxxxxxxxxxxx; required for AdSense revenue
 # custom script on header, example: custom_script= "<script>console.log(\"Hello World\")</script>"
 custom_script = ""
 # copyright
 copyright = "Designed & Developed by [Zeon Studio](https://zeon.studio)"
+
+# Google AdSense display ad slots.
+# Create these ad units in AdSense, then paste their numeric data-ad-slot IDs here.
+[adsense]
+article_bottom_slot = ""
+blog_list_slot = ""
 
 # Preloader
 # preloader module: https://github.com/gethugothemes/hugo-modules/tree/master/components/preloader

--- a/layouts/_partials/adsense/display-ad.html
+++ b/layouts/_partials/adsense/display-ad.html
@@ -1,0 +1,16 @@
+{{- $client := site.Params.google_adsense -}}
+{{- $slot := .Slot | default "" -}}
+{{- if and $client $slot -}}
+  <div class="{{ .Class | default `my-8` }}">
+    <ins
+      class="adsbygoogle block"
+      style="display:block"
+      data-ad-client="{{ $client }}"
+      data-ad-slot="{{ $slot }}"
+      data-ad-format="{{ .Format | default `auto` }}"
+      data-full-width-responsive="{{ .FullWidthResponsive | default `true` }}"></ins>
+    <script>
+      (adsbygoogle = window.adsbygoogle || []).push({});
+    </script>
+  </div>
+{{- end -}}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,36 @@
+{{ define "main" }}
+  {{ partial "page-header" . }}
+
+
+  <section class="section">
+    <div class="container">
+      <div class="row gx-5">
+        <!-- blog posts -->
+        <div class="lg:col-8">
+          <div class="row">
+            {{ $paginator:= .Paginate .RegularPages }}
+            {{ $adsenseClient := site.Params.google_adsense }}
+            {{ $blogListAdSlot := site.Params.adsense.blog_list_slot }}
+            {{ range $index, $page := $paginator.Pages }}
+              <div class="md:col-6 mb-14">
+                {{ partial "components/blog-card" $page }}
+              </div>
+              {{ if and $adsenseClient $blogListAdSlot (eq $index 1) }}
+                <div class="col-12 mb-14">
+                  {{ partial "adsense/display-ad.html" (dict "Slot" $blogListAdSlot) }}
+                </div>
+              {{ end }}
+            {{ end }}
+          </div>
+          {{ partial "components/pagination.html" . }}
+        </div>
+        <!-- sidebar -->
+        <div class="lg:col-4">
+          <!-- widget -->
+          {{ $widget:= site.Params.widgets.sidebar }}
+          {{ partialCached "widgets/widget-wrapper" ( dict "Widgets" $widget "Scope" . ) }}
+        </div>
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -44,6 +44,7 @@
             {{ partial "toc.html" (dict "Class" "blog" "Collapsed" false "TableOfContents" .TableOfContents ) }}
             {{ .Content }}
           </div>
+          {{ partial "adsense/display-ad.html" (dict "Slot" site.Params.adsense.article_bottom_slot "Class" "mb-10") }}
           <div class="row items-start justify-between">
             {{ $tags:= .Params.tags }}
             {{ if $tags }}


### PR DESCRIPTION
## What changed

- Added a reusable AdSense display ad partial that renders only when both `google_adsense` and a slot ID are configured.
- Added two configurable ad placements: after blog article content and inside the blog list after the second post.
- Documented the required AdSense publisher ID and slot IDs in `DEVELOPER_DOCS.md`.

## Why

The site already includes the HugoPlate AdSense script hook, but it only becomes useful when the publisher ID and ad unit slots are wired into templates. This adds revenue-ready placements without rendering empty ad containers while configuration is missing.

## Validation

- Ran `/private/tmp/hugo --gc --minify --ignoreCache` successfully.
- Confirmed empty AdSense configuration produces no `adsbygoogle`, `data-ad-client`, or `pagead2.googlesyndication` output in generated HTML.